### PR TITLE
Fix reconcile imports and cover _is_different behavior

### DIFF
--- a/reconcile.py
+++ b/reconcile.py
@@ -1,4 +1,4 @@
-# sales_reconcile.py – rotina de reconciliação (ajustada)
+# reconcile.py – rotina de reconciliação (ajustada)
 from __future__ import annotations
 
 import time

--- a/reconcile_daily.py
+++ b/reconcile_daily.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone, timedelta
 import logging
 from db import SessionLocal
 from models import UserToken
-from sales_reconcile import reconciliar_vendas  # importa a função que te enviei
+from reconcile import reconciliar_vendas  # importa a função que te enviei
 
 logging.basicConfig(
     level=logging.INFO,

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     startCommand: "./start.sh"
     envVars:
       - key: DB_URL
-        value: "postgresql://admin:pR6aFnyZm6nc1wlCheGVXvjJ5VZrLZQ6@dpg-d0d26gjuibrs73dra1tg-a.oregon-postgres.render.com/contazoom?sslmode=require"
+        value: 'postgresql://admin:pR6aFnyZm6nc1wlCheGVXvjJ5VZrLZQ6@dpg-d0d26gjuibrs73dra1tg-a.oregon-postgres.render.com/contazoom?sslmode=require'
       - key: ML_CLIENT_ID
         value: "3597957782423859"
       - key: ML_CLIENT_SECRET

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+import sys
+from pathlib import Path
+from types import ModuleType
+
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+# Evita dependências de banco e credenciais durante a importação de reconcile.py
+fake_db = ModuleType("db")
+fake_db.SessionLocal = None
+sys.modules["db"] = fake_db
+
+fake_oauth = ModuleType("oauth")
+fake_oauth.renovar_access_token = lambda *_args, **_kwargs: None
+sys.modules["oauth"] = fake_oauth
+
+fake_sales = ModuleType("sales")
+fake_sales._order_to_sale = lambda *_args, **_kwargs: None
+sys.modules["sales"] = fake_sales
+
+from reconcile import _is_different
+
+
+def test_is_different_normalizes_strings():
+    assert not _is_different("  valor ", "valor")
+    assert _is_different("valor", "outro")
+
+
+def test_is_different_respects_numeric_tolerance():
+    assert not _is_different(Decimal("10.00"), Decimal("10.005"))
+    assert _is_different(10.0, 10.02)
+
+
+def test_is_different_handles_none_values():
+    assert not _is_different(None, None)
+    assert _is_different(None, "algo")
+    assert _is_different("algo", None)


### PR DESCRIPTION
## Summary
- fix the Render deployment config so the DB_URL is stored as a single literal value
- point the daily reconciliation job at the renamed reconcile module
- update the reconcile module header comment to match the filename
- add unit tests that cover the _is_different helper across string, numeric, and None inputs

## Testing
- pytest tests/test_reconcile.py

------
https://chatgpt.com/codex/tasks/task_e_68cd9211f8d8832a9d95744bbca47cd8